### PR TITLE
Fix loading the proper home-$posttype.php file and fix phpunit

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
 >
     <testsuites>
         <testsuite name="integrtion">
-            <directory prefix="test-" suffix=".php">./tests/integration</directory>
+            <directory>./tests/integration</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -543,7 +543,7 @@ class Plugin
             return $templates;
         }
         return \array_merge([
-            "home-{$GLOBALS['wp_query']->{self::QUERY_VAR_IS_PFCPT}}",
+            "home-{$GLOBALS['wp_query']->{self::QUERY_VAR_IS_PFCPT}}.php",
         ], $templates);
     }
 

--- a/tests/integration/PageForCustomPostTypeTest.php
+++ b/tests/integration/PageForCustomPostTypeTest.php
@@ -7,7 +7,7 @@ use Mantle\Testkit\Test_Case as Testkit_Test_Case;
 use n5s\PageForCustomPostType\Plugin;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 
-class TestPageForCustomPostType extends Testkit_Test_Case
+class PageForCustomPostTypeTest extends Testkit_Test_Case
 {
     private string $home_for_book_title = 'Home for Books';
 
@@ -62,7 +62,7 @@ class TestPageForCustomPostType extends Testkit_Test_Case
         $hierarchy = new Hierarchy();
         $this->assertEquals([
             'home' => [
-                "home-{$this->book_post_type}",
+                "home-{$this->book_post_type}.php",
                 'home',
                 'index',
             ],


### PR DESCRIPTION
Related to this issue: https://github.com/nlemoine/page-for-custom-post-type/issues/5

I added `.php` in `set_home_template_hierarchy()` so that it load the right template file for custom post type archives.

Also removed the prefix and suffix in `phpunit.xml.dist` and renamed the test file/class so that PHPUnit properly find it.