### PR TITLE
test(polylang): boot Polylang in the test bootstrap so its suite runs

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -58,6 +58,16 @@ if ($isPolylang) {
             return;
         }
 
+        // Polylang only loads its API (the pll_* functions and PLL()) when
+        // init() enters a context via init_context(). In PHPUnit there is no
+        // request context and no languages exist yet, so init() detects an
+        // empty context and returns before requiring src/api.php — leaving
+        // PLL() undefined and every PolylangTest skipped. Force a frontend
+        // context so the API loads; languages are (re)created per test by
+        // TestCase::setPolylangDefaultLanguage() after Refresh_Database rolls
+        // them back.
+        add_filter('pll_context', static fn (string $class): string => $class ?: 'PLL_Frontend');
+
         $polylangBootstrap = new \Polylang();
         $polylangBootstrap->init();
     });


### PR DESCRIPTION
## Problem

Coverage reports `src/Integration/Polylang/` at 0%. Every `PolylangTest` silently skips via `markTestSkipped('Polylang is not installed.')`, because `function_exists('PLL')` is false during the test run even though the plugin is installed.

## Root cause

Polylang 3.7+ loads its API (`PLL()` and the `pll_*` functions, in `src/api.php`) only from `Polylang::init_context()`. `init()` reaches `init_context()` only when it detects a context — admin, REST, or frontend **with languages defined**.

Under PHPUnit there is no request context, and languages are created per test (after `Refresh_Database` rolls them back), so at bootstrap `init()` sees an empty context, returns before requiring `src/api.php`, and `PLL()` is never defined. The existing bootstrap call (`new \Polylang(); ->init();`) is therefore a no-op for loading the API.

This surfaced after Polylang updated past its loader refactor (composer allows `^3.4`; 3.8.4 is installed).

## Fix

Force a frontend context through Polylang's own `pll_context` filter so `init_context()` runs and loads the API. This completes the original intent — `TestCase::setPolylangDefaultLanguage()` already recreates languages per test, assuming Polylang booted once at bootstrap.

## Verification

- `src/Integration/Polylang/` coverage: **0% → ~79%** (88/112 statements); all six classes now exercised.
- `PLUGINS=polylang … --testsuite=plugin-integration`: **43 passed, 0 failures, no Polylang skips** — un-skipping surfaced no real bugs.
- `phpcs` and PHPStan clean on `tests/bootstrap.php`.
- The change is guarded by `$isPolylang`, so non-Polylang suites are unaffected.
